### PR TITLE
Fix rich soil farmland negating fall damage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ repositories {
         name = "shedaniel - cloth config"
     }
     maven {
-        url = "https://maven.jaackson.me"
+        url = "https://maven.teamabnormals.com/"
     }
     exclusiveContent {
         forRepository {

--- a/src/main/java/cc/cassian/raspberry/mixin/farmersdelight/RichSoilFarmlandBlockMixin.java
+++ b/src/main/java/cc/cassian/raspberry/mixin/farmersdelight/RichSoilFarmlandBlockMixin.java
@@ -1,0 +1,22 @@
+package cc.cassian.raspberry.mixin.farmersdelight;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import vectorwing.farmersdelight.common.block.RichSoilFarmlandBlock;
+
+@Mixin(RichSoilFarmlandBlock.class)
+public class RichSoilFarmlandBlockMixin {
+    // Make Rich Soil Farmland not negate all fall damage.
+    // This restores the implementation of Block::fallOn.
+    @Inject(at = @At(value = "HEAD"), method = "fallOn")
+    public void fallOn(Level level, BlockState state, BlockPos pos, Entity entity, float fallDistance, CallbackInfo ci) {
+        entity.causeFallDamage(fallDistance, 1.0F, DamageSource.FALL);
+    }
+}

--- a/src/main/resources/raspberry.mixins.json
+++ b/src/main/resources/raspberry.mixins.json
@@ -47,6 +47,7 @@
 	"farmersdelight.FarmBlockMixin",
 	"farmersdelight.FlintAndSteelMixin",
 	"farmersdelight.NetherStoveBlockMixin",
+	"farmersdelight.RichSoilFarmlandBlockMixin",
 	"farmersdelight.StoveBlockMixin",
 	"naturalist.SnakeMixin",
 	"oreganized.EnchantmentHelperMixin",


### PR DESCRIPTION
Restores the `Block::fallOn behavior` by adding back the fall damage calculation call. Gotta love one-liner mixins.