### PR TITLE
Fix deployers not giving the bumblebee music discs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,7 @@ dependencies {
     modCompileOnly("local:ecologics-forge:1.19.2-2.1.11") // jar built locally to avoid errors when importing the project
     modImplementation("maven.modrinth:spyglass-improvements:${spyglass_improvements_version}")
     modRuntimeOnly("top.theillusivec4.curios:curios-forge:${curios_version}") // dependency of sypyglass improvements
+    modImplementation("curse.maven:windsweptmod-636321:$windswept_version")
 
     // mods for testing purposes
     modImplementation("curse.maven:map-atlases-forge-519759:5138314")

--- a/gradle.properties
+++ b/gradle.properties
@@ -53,6 +53,7 @@ kubejs_version = 1902.6.2-build.73
 screenshot_viewer_version = 1.19-forge-2
 spyglass_improvements_version = 1.5+mc1.19+forge
 curios_version = 1.19.2-5.1.6.4
+windswept_version = 4817132
 
 # Gliders
 gliders_version = 1.1.4+forge

--- a/src/main/java/cc/cassian/raspberry/ModCompat.java
+++ b/src/main/java/cc/cassian/raspberry/ModCompat.java
@@ -27,5 +27,5 @@ public final class ModCompat {
     public static final boolean SURVIVALITY = ModList.get().isLoaded("survivality");
     public static final boolean SUPPLEMENTARIES = ModList.get().isLoaded("supplementaries");
     public static final boolean SPELUNKERY = ModList.get().isLoaded("spelunkery");
-
+    public static final boolean WINDSWEPT = ModList.get().isLoaded("windswept");
 }

--- a/src/main/java/cc/cassian/raspberry/mixin/create/DeployerHandlerMixin.java
+++ b/src/main/java/cc/cassian/raspberry/mixin/create/DeployerHandlerMixin.java
@@ -1,0 +1,53 @@
+package cc.cassian.raspberry.mixin.create;
+
+import cc.cassian.raspberry.ModCompat;
+import cc.cassian.raspberry.RaspberryMod;
+import com.simibubi.create.content.kinetics.deployer.DeployerHandler;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Random;
+
+@Mixin(DeployerHandler.class)
+public class DeployerHandlerMixin {
+    private static final ResourceLocation BEE_DISC_ID = new ResourceLocation("windswept", "music_disc_bumblebee");
+
+    // > smallest inject annotation
+    @Inject(at = @At(value = "INVOKE",
+                     target = "Lnet/minecraft/world/entity/player/Inventory;placeItemBackInInventory(Lnet/minecraft/world/item/ItemStack;)V",
+                     shift = At.Shift.AFTER),
+            method = "safeOnBeehiveUse(Lnet/minecraft/world/level/block/state/BlockState;" +
+                                      "Lnet/minecraft/world/level/Level;" +
+                                      "Lnet/minecraft/core/BlockPos;" +
+                                      "Lnet/minecraft/world/entity/player/Player;" +
+                                      "Lnet/minecraft/world/InteractionHand;" +
+                                      ")" + "Lnet/minecraft/world/InteractionResult;")
+    private static void addBeeDiscDropOnDeployerShearingHive(BlockState state, Level world, BlockPos pos, Player player,
+                                                               InteractionHand hand, CallbackInfoReturnable<InteractionResult> ci) {
+        if (!ModCompat.WINDSWEPT) return;
+
+        Random random = new Random();
+        int roll = random.nextInt(200); // Amounts to 0.5% (1/200) chance, same as the KubeJS chance
+        if (roll != 0) return;
+
+        Item discItem = ForgeRegistries.ITEMS.getValue(BEE_DISC_ID);
+        if (discItem == null) {
+            RaspberryMod.LOGGER.error("Failed to find music disc item {}!", BEE_DISC_ID);
+            return;
+        }
+
+        player.getInventory().placeItemBackInInventory(new ItemStack(discItem, 1));
+    }
+}

--- a/src/main/resources/raspberry.mixins.json
+++ b/src/main/resources/raspberry.mixins.json
@@ -31,6 +31,7 @@
 	"cofh_core.EffectEventsMixin",
 	"create.AllFluidsMixin",
 	"create.BlastingTypeMixin",
+	"create.DeployerHandlerMixin",
 	"create.FanProcessingMixin",
 	"create.GogglesItemMixin",
 	"create.MountedStorageMixin",


### PR DESCRIPTION
[This is the offending part in the Create source code.](https://github.com/Creators-of-Create/Create/blob/mc1.20.1/dev/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java#L430) Basically, instead of doing an actual right click with the fake player, Create just magically gives three honeycomb to the deployer fake player. The mixin just gives the fake player the disc too, if the drop is rolled.